### PR TITLE
fix: Translate status messages and error prompts to English for consistency

### DIFF
--- a/js/views/candidatesPage.js
+++ b/js/views/candidatesPage.js
@@ -100,8 +100,8 @@ function renderCandidatesCards() {
         // Show no candidates message
         const hasActiveFilters = currentFilters.search || currentFilters.occupation || currentFilters.skill;
         const message = hasActiveFilters
-            ? 'No hay candidatos que coincidan con los filtros aplicados'
-            : 'No hay candidatos disponibles';
+            ? 'There are not matching candidates'
+            : 'There are not available candidates';
 
         container.innerHTML = `
             <div class="px-6 py-8 text-center text-gray-500">
@@ -110,7 +110,7 @@ function renderCandidatesCards() {
                         <path d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Z"/>
                     </svg>
                     <p class="font-medium text-gray-600">${message}</p>
-                    <p class="text-sm text-gray-400">Intenta ajustar los filtros o revisar la conexion</p>
+                    <p class="text-sm text-gray-400">Intenta ajustar los filtros o revisar la conexion, Check the filter or check your connection</p>
                 </div>
             </div>
         `;

--- a/js/views/vacanciePage.js
+++ b/js/views/vacanciePage.js
@@ -338,9 +338,9 @@ function showStatusChangeModal(applicationId) {
         option.disabled = false;
         option.style.color = '';
         option.style.backgroundColor = '';
-        // Clean any previous "(Estado Actual)" text
-        if (option.textContent.includes(' (Estado Actual)')) {
-            option.textContent = option.textContent.replace(' (Estado Actual)', '');
+        // Clean any previous "(Current Status)" text
+        if (option.textContent.includes(' (Current Status)')) {
+            option.textContent = option.textContent.replace(' (Current Status)', '');
         }
     });
 
@@ -350,7 +350,7 @@ function showStatusChangeModal(applicationId) {
         currentOption.disabled = true;
         currentOption.style.color = '#9CA3AF'; // text-gray-400
         currentOption.style.backgroundColor = '#F9FAFB'; // bg-gray-50
-        currentOption.textContent = currentOption.textContent + ' (Estado Actual)';
+        currentOption.textContent = currentOption.textContent + ' (Current Status)';
     }
 
     // Set select to first available option (not current status)
@@ -370,7 +370,7 @@ function showStatusChangeModal(applicationId) {
  * Hide status change modal
  */
 function hideStatusChangeModal() {
-    // Clean up select options (remove "(Estado Actual)" text and reset states)
+    // Clean up select options (remove "(Current Status)" text and reset states)
     const statusSelect = document.getElementById('modal-status-select');
     if (statusSelect) {
         const options = statusSelect.querySelectorAll('option');
@@ -379,9 +379,9 @@ function hideStatusChangeModal() {
             option.disabled = false;
             option.style.color = '';
             option.style.backgroundColor = '';
-            // Remove "(Estado Actual)" text if present
-            if (option.textContent.includes(' (Estado Actual)')) {
-                option.textContent = option.textContent.replace(' (Estado Actual)', '');
+            // Remove "(Current Status)" text if present
+            if (option.textContent.includes(' (Current Status)')) {
+                option.textContent = option.textContent.replace(' (Current Status)', '');
             }
         });
     }
@@ -412,11 +412,11 @@ async function updateApplicationStatus(applicationId, newStatus) {
         // Reload all data to ensure consistency - this will also re-render everything
         await loadVacancyData();
 
-        showSuccess(`Estado actualizado a ${getApplicationStatusConfig(newStatus).label}`);
+        showSuccess(`Status updates to ${getApplicationStatusConfig(newStatus).label}`);
 
     } catch (error) {
         console.error('Error updating application status:', error);
-        showError('Error al actualizar el estado de la aplicación');
+        showError('Error updating application status:');
     }
 }
 
@@ -561,7 +561,7 @@ function setupModalEventListeners() {
             await updateApplicationStatus(pendingStatusChange.applicationId, newStatus);
             hideStatusChangeModal();
         } else {
-            showError('Por favor selecciona un estado');
+            showError('Choose a status');
         }
     });
 


### PR DESCRIPTION
This pull request updates user-facing messages in the candidate and vacancy management pages to use English instead of Spanish, providing a more consistent experience for English-speaking users. The changes focus on status messages, filter prompts, and modal instructions.

**User Interface Text Updates:**

* Updated candidate filter and availability messages in `renderCandidatesCards` to English, and added a bilingual suggestion to check filters or connection. (`js/views/candidatesPage.js`) [[1]](diffhunk://#diff-e264bd70d5e9205fe2ac95c2640e4b0620d096f50e76d6a5a7d324805fde838eL103-R104) [[2]](diffhunk://#diff-e264bd70d5e9205fe2ac95c2640e4b0620d096f50e76d6a5a7d324805fde838eL113-R113)
* Changed all status-related option labels and modal instructions from "(Estado Actual)" to "(Current Status)" and updated related comments. (`js/views/vacanciePage.js`) [[1]](diffhunk://#diff-6242a75fdba4c7ae54face8fb08a2afe183aa918d7498545296df19086641f5bL341-R343) [[2]](diffhunk://#diff-6242a75fdba4c7ae54face8fb08a2afe183aa918d7498545296df19086641f5bL353-R353) [[3]](diffhunk://#diff-6242a75fdba4c7ae54face8fb08a2afe183aa918d7498545296df19086641f5bL373-R373) [[4]](diffhunk://#diff-6242a75fdba4c7ae54face8fb08a2afe183aa918d7498545296df19086641f5bL382-R384)

**Status Update Notifications:**

* Modified success and error messages for application status updates to English ("Status updates to..." and "Error updating application status:"). (`js/views/vacanciePage.js`)
* Changed the error message shown when no status is selected to "Choose a status". (`js/views/vacanciePage.js`)