### PR TITLE
refactor: update references from TalentTrack to Elevate in HTML and t…

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                     Trusted by forward-thinking companies
                 </h2>
                 <p id= "introSubtitle" class="text-base md:text-lg text-gray-600 max-w-3xl mx-auto leading-relaxed px-4">
-                    Join industry leaders who rely on TalentTrack to build exceptional teams and scale their recruitment
+                    Join industry leaders who rely on Elevate to build exceptional teams and scale their recruitment
                     processes efficiently.
                 </p>
             </div>
@@ -336,7 +336,7 @@
                             Empowering Recruiters and Hiring Managers
                         </h2>
                         <p id="paragraphMain4" class="text-base md:text-lg text-gray-600 leading-relaxed">
-                            Join leading companies that trust TalentTrack to streamline their hiring
+                            Join leading companies that trust Elevate to streamline their hiring
                             workflow and discover top talent efficiently.
                         </p>
                     </div>
@@ -404,7 +404,7 @@
                                         </svg>
                                     </div>
                                     <span
-                                        class="text-gray-600 group-hover:text-blue-600 transition-colors text-sm">support@talenttrack.com</span>
+                                        class="text-gray-600 group-hover:text-blue-600 transition-colors text-sm">support@Elevate.com</span>
                                 </div>
                                 <div class="flex items-center space-x-3 group cursor-pointer">
                                     <div
@@ -426,7 +426,7 @@
                     <!-- Bottom Section -->
                     <div
                         class="border-t border-gray-200 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center text-sm text-gray-500">
-                        <p>© 2025 TalentTrack. All rights reserved.</p>
+                        <p>© 2025 Elevate. All rights reserved.</p>
                         <div class="flex items-center space-x-2 mt-4 md:mt-0">
                             <div class="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
                             <span id="spanFooter" class="text-xs">All systems operational</span>

--- a/js/views/translate.js
+++ b/js/views/translate.js
@@ -11,7 +11,7 @@ const translations = {
       imgText: "Reduced our time-to-hire by 60%",
       imgText_2: "Sarah Chen, Head of Talent",
       introTitle: "Trusted by forward-thinking companies",
-      introSubtitle: "Join industry leaders who rely on TalentTrack to build exceptional teams and scale their recruitment processes efficiently.",
+      introSubtitle: "Join industry leaders who rely on Elevate to build exceptional teams and scale their recruitment processes efficiently.",
       InnovateCorp: "InnovateCorp",
       DataFlow: "DataFlow",
       TechBuild: "TechBuild",
@@ -27,11 +27,11 @@ const translations = {
       paragraphMain3: "Connect with your existing tools and workflows without disruption.",
       paragraphImg: "Reduced our time-to-hire by 60% while improving candidate quality significantly.",
       titleMain: "Empowering Recruiters and Hiring Managers",
-      paragraphMain4: "Join leading companies that trust TalentTrack to streamline their hiring workflow and discover top talent efficiently.",
+      paragraphMain4: "Join leading companies that trust Elevate to streamline their hiring workflow and discover top talent efficiently.",
       paragraphFooter: "Modern recruitment platform designed to help scaling companies build exceptional teams through intelligent candidate matching and data-driven insights.",
       GetItTouch: "Get in Touch",
       spanFooter: "All systems operational",
-      footerText: "© 2025 TalentTrack. All rights reserved."
+      footerText: "© 2025 Elevate. All rights reserved."
     },
     es: {
       loginBtn: "Iniciar sesión",
@@ -44,7 +44,7 @@ const translations = {
       imgText: "Reducimos nuestro tiempo de contratación en un 60%",
       imgText_2: "Sarah Chen, Jefa de Talento",
       introTitle: "Confiado por empresas visionarias",
-      introSubtitle: "Únete a líderes de la industria que confían en TalentTrack para formar equipos excepcionales y optimizar sus procesos de reclutamiento.",
+      introSubtitle: "Únete a líderes de la industria que confían en Elevate para formar equipos excepcionales y optimizar sus procesos de reclutamiento.",
       InnovateCorp: "InnovateCorp",
       DataFlow: "DataFlow",
       TechBuild: "TechBuild",
@@ -60,11 +60,11 @@ const translations = {
       paragraphMain3: "Conéctate con tus herramientas y flujos de trabajo existentes sin interrupciones.",
       paragraphImg: "Reducimos nuestro tiempo de contratación en un 60% mientras mejoramos significativamente la calidad de los candidatos.",
       titleMain: "Empoderando a reclutadores y gerentes de contratación",
-      paragraphMain4: "Únete a empresas líderes que confían en TalentTrack para optimizar su flujo de trabajo y descubrir el mejor talento de manera eficiente.",
+      paragraphMain4: "Únete a empresas líderes que confían en Elevate para optimizar su flujo de trabajo y descubrir el mejor talento de manera eficiente.",
       paragraphFooter: "Plataforma moderna de reclutamiento diseñada para ayudar a las empresas en crecimiento a construir equipos excepcionales mediante la coincidencia inteligente de candidatos y el análisis basado en datos.",
       GetItTouch: "Ponte en contacto",
       spanFooter: "Todos los sistemas operativos",
-      footerText: "© 2025 TalentTrack. Todos los derechos reservados."
+      footerText: "© 2025 Elevate. Todos los derechos reservados."
     }
   };
   


### PR DESCRIPTION
This pull request updates the application's branding from "TalentTrack" to "Elevate" across both the English and Spanish versions of the landing page and its translations. The changes ensure that all user-facing references, including taglines, contact information, and copyright notices, reflect the new product name.

Branding updates in user-facing content:

* Replaced all instances of "TalentTrack" with "Elevate" in key landing page sections such as taglines, workflow descriptions, and copyright notices in `index.html`. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L185-R185) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L339-R339) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L407-R407) [[4]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L429-R429)

Branding updates in translations:

* Updated the English and Spanish translation entries in `js/views/translate.js` to use "Elevate" instead of "TalentTrack" in all relevant fields, including subtitles, workflow descriptions, and copyright text. [[1]](diffhunk://#diff-f23c7cfa71cb9765d137e1374ebb494d390c9568575470e625abf37e1f66bcedL14-R14) [[2]](diffhunk://#diff-f23c7cfa71cb9765d137e1374ebb494d390c9568575470e625abf37e1f66bcedL30-R34) [[3]](diffhunk://#diff-f23c7cfa71cb9765d137e1374ebb494d390c9568575470e625abf37e1f66bcedL47-R47) [[4]](diffhunk://#diff-f23c7cfa71cb9765d137e1374ebb494d390c9568575470e625abf37e1f66bcedL63-R67)